### PR TITLE
fix: add CFG_sync() call to CFG_setFontId to save font settings

### DIFF
--- a/workspace/all/common/config.c
+++ b/workspace/all/common/config.c
@@ -329,6 +329,8 @@ void CFG_setFontId(int id)
 
     if(settings.onFontChange)
         settings.onFontChange(fontPath);
+
+    CFG_sync();
 }
 
 uint32_t CFG_getColor(int color_id)


### PR DESCRIPTION
Fix font settings not being saved after device restart